### PR TITLE
Update redhatopenshift_cluster.md

### DIFF
--- a/docs/resources/redhatopenshift_cluster.md
+++ b/docs/resources/redhatopenshift_cluster.md
@@ -41,7 +41,7 @@ description: |-
 
 - `console_url` (String)
 - `id` (String) The ID of this resource.
-- `version` (String)
+
 
 <a id="nestedblock--master_profile"></a>
 ### Nested Schema for `master_profile`


### PR DESCRIPTION
Removed  the information that states the variable “version” as read-only, since could mislead customers regarding the ability to set the cluster version using TF.